### PR TITLE
UTF-8 encoder error

### DIFF
--- a/load_data.py
+++ b/load_data.py
@@ -28,7 +28,9 @@ def load_data_into_es(es):
     gazette_list = glob.glob('{}*.txt'.format(path))
 
     for index, gazzete in enumerate(gazette_list):
-        with open(gazzete) as file:
+        # the errors='ignore' argument make the utf8 encoder ignore the chars
+        # it cannot parse.
+        with open(gazzete, 'r', encoding='utf8', errors='ignore') as file:
             data = file.read()
             ret = es.index(
                 index=INDEX_NAME,


### PR DESCRIPTION
There are some files which contain invalid UTF-8 chars. This breaks the
script. To avoid that, an additional arguments has been added in the
"open" call. The "errors='ignore'". This arguments makes the UTF-8
encoder ignore the char which it does not understand. Thus, the script
will not break.

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>